### PR TITLE
Fixed grammatical mistake

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -148,10 +148,10 @@
                     <div class="code-block code-space">&lt;a href=&quot;#&quot; class=&quot;button&quot; data-micron=&quot;bounce&quot; data-micron-bind=&quot;true&quot;
                         data-micron-id=&quot;me&quot;&gt;Label&lt;/a&gt;
                     </div>
-                    <div class="code-block code-space">&lt;a href=&quot;#&quot; class=&quot;button&quot; id=&quot;me&quot;&gt;Binded&lt;/a&gt;</div>
+                    <div class="code-block code-space">&lt;a href=&quot;#&quot; class=&quot;button&quot; id=&quot;me&quot;&gt;Bound&lt;/a&gt;</div>
                     <p class="example-code">Example Code Preview</p>
                     <a href="#" class="button" data-micron="bounce" data-micron-bind="true" data-micron-id="me">Label</a>
-                    <a href="#" class="button" id="me">Binded</a>
+                    <a href="#" class="button" id="me">Bound</a>
 
                     <h2 id="access-inside-javascript">Access inside JavaScript</h2>
                     <p>Call micron chained methods to apply interactions to any DOM Element, right in your custom block of JavaScript


### PR DESCRIPTION
The past tense of "bind" is "bound" (not "binded").